### PR TITLE
Support for building tags

### DIFF
--- a/src/GitHubFlowVersion/GitHelper.cs
+++ b/src/GitHubFlowVersion/GitHelper.cs
@@ -77,13 +77,14 @@ namespace GitHubFlowVersion
         {
             EnsureOnlyOneRemoteIsDefined(repository);
             CreateMissingLocalBranchesFromRemoteTrackingOnes(repository);
+            
+            if(CheckIfHeadIsAPullRequest(repository))
+                CreateFakeBranchPointingAtThePullRequestTip(repository);
+        }
 
-            if (!repository.Info.IsHeadDetached)
-            {
-                return;
-            }
-
-            CreateFakeBranchPointingAtThePullRequestTip(repository);
+        static bool CheckIfHeadIsAPullRequest(IRepository repository)
+        {
+            return repository.Info.IsHeadDetached && repository.Tags.All(t => t.Target != repository.Head.Tip);
         }
 
         static void EnsureOnlyOneRemoteIsDefined(IRepository repo)


### PR DESCRIPTION
We found a bit of an issue in the logic used to determine whether a branch is a pull request - namely that if you were on a disconnected head by way of checking out a particular tag, we would attempt to run the pull-request logic which would result in the error "Found more than one remote tip from remote, unable to determine which one to use."

Our slightly modified version of githubflow uses tags to deploy to different environments, and additionally the base githubflow workflow should allow for deploying past tags. In the current version, this fails as above.

Now we check both for disconnected heads and for whether the tip of the head is a tag before deciding that our branch is a pull request.
